### PR TITLE
feat: add dep-bin package

### DIFF
--- a/dep-bin/LICENSE
+++ b/dep-bin/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2014 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/dep-bin/PKGBUILD
+++ b/dep-bin/PKGBUILD
@@ -3,7 +3,7 @@
 # contributer: Alif Rachmawadi <arch@subosito.com>
 pkgname=dep-bin
 pkgver=0.5.4 # renovate: datasource=github-releases depName=golang/dep
-pkgrel=3
+pkgrel=1
 pkgdesc="Go dependency management tool"
 pkgoption1="dep-linux-amd64"
 pkgoption2="dep-linux-arm64"

--- a/dep-bin/PKGBUILD
+++ b/dep-bin/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Moses Narrow <moe_narrow@use.startmail.com>
+# Maintainer: Chris Werner Rau < aur [ at ] cwrau [ dot ] io >
+# contributer: Alif Rachmawadi <arch@subosito.com>
+pkgname=dep-bin
+pkgver=0.5.4 # renovate: datasource=github-releases depName=golang/dep
+pkgrel=3
+pkgdesc="Go dependency management tool"
+pkgoption1="dep-linux-amd64"
+pkgoption2="dep-linux-arm64"
+arch=('any')
+url="https://github.com/golang/dep"
+license=('BSD')
+conflicts=('dep')
+provides=('dep')
+#detect architecture & adjust source & checksums accordingly
+sha256sums=('69c47f09a7aec01c59ff1bdc346406d36e84df11461fb2bed92b0d185a7a2ccb')
+case "$CARCH" in
+	arm*) _pkgarch="$pkgoption2"
+		sha256sums+=('9dbf1612044598cbb195933213eb3c4bab5d4ada0ce5b90a91241c4431b1783a')
+		;;
+  aarch64*) _pkgarch="$pkgoption2"
+    sha256sums+=('9dbf1612044598cbb195933213eb3c4bab5d4ada0ce5b90a91241c4431b1783a')
+    ;;
+	x86_64) _pkgarch="$pkgoption1"
+		sha256sums+=('40a78c13753f482208d3f4bea51244ca60a914341050c588dad1f00b1acc116c')
+		;;
+esac
+source=("LICENSE" "${url}/releases/download/v${pkgver}/$_pkgarch")
+
+package() {
+	install -Dm755 dep-linux-a* ${pkgdir}/usr/bin/dep
+	install -Dm644 LICENSE ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a LICENSE file outlining usage terms and permissions.
  - Introduced a PKGBUILD file for packaging and installing the dep-bin tool, supporting amd64 and arm64 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->