### PR TITLE
feat: add helmrelease-tools package

### DIFF
--- a/helmrelease-tools/PKGBUILD
+++ b/helmrelease-tools/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer Chris Werner Rau <aur@cwrau.io>
+
+_pkgname=helmrelease-tools
+pkgname=$_pkgname
+pkgver=2.11.0
+pkgrel=1
+pkgdesc="Scripts to work with flux HelmReleases"
+license=('APACHE')
+arch=('x86_64')
+depends=("yq" "git" "helm" "fd" "ripgrep" "helm-diff" "zsh")
+source=("hr" "hrDiff" "hrInstall" "hrUpgrade" "helmrelease" "hrUninstall" "_$pkgname")
+sha512sums=('ec0c945d04644975db3f6df538520475a16b6ab3bda3d0b3e331cd978b27574b215194bad48a015a77ad087a2aea4d49898e66a0f0e138d2d137791a29d5377f'
+            '786c2b7fe6372001d362447f06b5142ce4dde736175ee76ba809685cf698918c5d57d6c72a4fa0ec1ef13826802778f7e87142745437c171eecf301e0b1ca50d'
+            '641ebf0b0a6db993c7b38135cc6b44b05ad684e2032571a5bddf786486871eefe2a3dd54fdce7568d9af15352fc480acf105248e0007b3a0802515582d3117cf'
+            '758350abf5f96a5fbd3bbb53b93a32e5517bf81bd6d67442e14f0f23d55b25142849d5ed7c2f721a5fa05f375c92dd472b69c9ffbaefb7e04c25f1f627e6b6ce'
+            '4109e26768fce3bf19bc689fb15f7e9fee9c36b8cf211c8e8de358b383c9e5cc02e13728a6f747c711193574735971836467e7349542dd45024f628351106ab6'
+            '3d0c0e7efad29577c944d631188ee86183b53a0a9e72b294c30101b202842a2d2af2c93d18628b768606e9cfff078a55e8f7b9164351ce069bc1f1553127ece0'
+            'b773209b957fd9c90c82e39507cfb549c4d2bb55f8fdc49a7d61d0ef72331810f21cb6d8c9d5885b8dad948c2f6c8cdab745894bd986e857582039ed434784f1')
+conflicts=("$_pkgname" "${_pkgname}-git")
+
+package() {
+  install -D -t "$pkgdir/usr/share/zsh/site-functions" "$srcdir/_$pkgname"
+  for s in "${source[@]}"; do
+    [[ "$s" == "_$pkgname" ]] && continue
+    install -D -t "$pkgdir/usr/bin" "$srcdir/$s"
+  done
+}
+
+#vim: syntax=sh

--- a/helmrelease-tools/_helmrelease-tools
+++ b/helmrelease-tools/_helmrelease-tools
@@ -1,0 +1,122 @@
+#compdef hr hrDiff hrInstall hrUninstall hrUpgrade
+
+function _hr_clean_search_path() {
+  local searchPath="$1"
+  if [[ "${searchPath:0:2}" == "~/" ]]; then
+    searchPath="$HOME/${searchPath:2}"
+  fi
+  if [[ ! -d "${searchPath}" ]]; then
+    searchPath="$(dirname "${searchPath}")"
+  fi
+  if [[ ! -d "${searchPath}" ]]; then
+    searchPath=
+  fi
+  echo "$searchPath"
+}
+
+function _hr_mangle_search_results() {
+  local originalSearchPath="$1"
+  local -a results=( "${@:2}" )
+  if [[ "${originalSearchPath:0:2}" == "~/" ]]; then
+    results=( "${results[@]/#$HOME/~}" )
+  fi
+  echo "${results[@]}"
+}
+
+function _hr_chart_folders() {
+  local -a chartSources
+  local originalSearchPath="${words[CURRENT]}"
+  local searchPath="${originalSearchPath}"
+  local replacedTilde=false
+  searchPath="$(_hr_clean_search_path "$searchPath")"
+  chartSources=( $(fd ${searchPath:+--search-path="${searchPath}"} -t f Chart.yaml -X dirname) )
+  chartSources=( $(_hr_mangle_search_results "$originalSearchPath" "${chartSources[@]}") )
+  _wanted sources expl 'Helm Chart source' \
+    _multi_parts -f / chartSources
+}
+
+function _hr_chart_tarballs() {
+  local -a chartTarballs
+  local originalSearchPath="${words[CURRENT]}"
+  local searchPath="${originalSearchPath}"
+  local replacedTilde=false
+  searchPath="$(_hr_clean_search_path "$searchPath")"
+  chartTarballs=( $(fd ${searchPath:+--search-path="${searchPath}"} --no-ignore -t f -e tgz -e tar) )
+  chartTarballs=( $(for tarball in "${chartTarballs[@]}"; do tar --wildcards -atf "$tarball" \*/Chart.yaml &>/dev/null && echo "$tarball"; done) )
+  chartTarballs=( $(_hr_mangle_search_results "$originalSearchPath" "${chartTarballs[@]}") )
+  _wanted sources expl 'Helm Chart tarballs' \
+    _multi_parts -f / chartTarballs
+}
+
+function _hr_charts() {
+  _alternative 'chart_folders:Helm Chart source:_hr_chart_folders' \
+    'chart_tars:Helm Chart tarballs:_hr_chart_tarballs'
+}
+function _hr_yamls() {
+  local -a hrs
+  local originalSearchPath="${words[CURRENT]}"
+  local searchPath="${originalSearchPath}"
+  searchPath="$(_hr_clean_search_path "$searchPath")"
+  hrs=( $(fd ${searchPath:+--search-path="${searchPath}"} -t f -e yaml -e yml -X rg '^kind: HelmRelease$' -l) )
+  hrs=( $(_hr_mangle_search_results "$originalSearchPath" "${hrs[@]}") )
+  _wanted yamls expl 'HelmRelease yaml' \
+    _multi_parts -f / hrs
+}
+function _hr_helm_opts() {
+  local -a command=( ${words[1]:2:l} )
+  [[ "${#command}" -eq 0 ]] && command=( template )
+  [[ "${command[1]}" == diff ]] && command=( diff upgrade )
+  local seperatorIndex=${words[(Ie)--]}
+  local -a newWords=( helm "${command[@]}" "${words[$seperatorIndex+1,-1]}" )
+  if [[ "${newWords[-1]}" == "" && "$CURRENT" == $(( seperatorIndex + ${#command} )) ]]; then
+    newWords[-1]=-
+  fi
+  local CURRENT=$(( CURRENT - seperatorIndex + ${#command} + 1 ))
+  local words=( "${newWords[@]}" )
+  _helm
+}
+function _hr_both() {
+  _alternative 'yamls:Flux HelmRelease yaml:_hr_yamls' \
+    'sources:Helm Chart source:_hr_charts'
+}
+function _hr_one() {
+  local firstParam="${words[CURRENT-1]}"
+  if [[ "${firstParam:0:2}" == "~/" ]]; then
+    firstParam="$HOME/${firstParam:2}"
+  fi
+  if [[ -f "${firstParam}" ]] || [[ "$firstParam" == - ]]; then
+    _alternative 'sources:Helm Chart source:_hr_charts'
+  else
+    _alternative 'yamls:Flux HelmRelease yaml:_hr_yamls'
+  fi
+}
+function _hr() {
+  case "${words[(Ie)--]}" in
+    2)
+      _arguments "1:seperator:(--)" \
+        "*:helm:_hr_helm_opts"
+      ;;
+    3)
+      _arguments "1:first:_hr_one" \
+        "2:seperator:(--)" \
+        "*:helm:_hr_helm_opts"
+      ;;
+    4)
+      ;&
+    0)
+      _arguments "1:first:_hr_both" \
+        "2:second:_hr_one" \
+        "3:seperator:(--)" \
+        "*:helm:_hr_helm_opts"
+    ;;
+  esac
+}
+
+case $service in
+  hr|hrDiff|hrInstall|hrUninstall|hrUpgrade)
+    _hr
+    ;;
+  *)
+    _message "unknown command ${service}" && ret=1
+    ;;
+esac

--- a/helmrelease-tools/helmrelease
+++ b/helmrelease-tools/helmrelease
@@ -1,0 +1,292 @@
+#!/usr/bin/env zsh
+
+set -e
+
+function err() {
+  info "${@}"
+  return 1
+}
+
+function info() {
+  echo "${@}" >&2
+}
+
+function _hr_getYaml() {
+  local yaml="$1"
+  local index="$2"
+  local kind="$3"
+
+  <<<"$yaml" | yq -erys "map(select(.kind == \"$kind\"))[$index]"
+}
+
+function _hr_getNamespace() {
+  local yaml="$1"
+
+  <<<"$yaml" | yq -er '.spec.targetNamespace // .metadata.namespace // ""'
+}
+
+function _hr_getReleaseName() {
+  local yaml="$1"
+  local ns
+
+  if <<<"$yaml" | yq -e '.apiVersion == "helm.fluxcd.io/v1" or .spec.targetNamespace' > /dev/null; then
+    <<<"$yaml" | yq -er ".spec.releaseName // \"$(_hr_getNamespace "$yaml")-\\(.metadata.name)\""
+  else
+    <<<"$yaml" | yq -er '.spec.releaseName // .metadata.name'
+  fi
+}
+
+function _parse_hr_subcommand() {
+  local clusterConnected="${1?}"
+  local subCommand="${2?}"
+  local validCommand="$clusterConnected"
+  local commands=()
+  case "$subCommand" in
+    template)
+      commands+=("template")
+      if [[ "$clusterConnected" == true ]]; then
+        commands+=("--dry-run=server")
+      else
+        info "Not connected to cluster, template might not be the exact result"
+      fi
+      validCommand=true
+      ;;
+    diff)
+      commands+=("diff" "upgrade" "--show-secrets" "--color" "--output=dyff")
+      ;;
+    install)
+      commands+=("install")
+      ;;
+    upgrade)
+      commands+=("upgrade")
+      ;;
+    uninstall)
+      commands+=("uninstall")
+      ;;
+    *)
+      err "command '$subCommand' is not implemented"
+      ;;
+  esac
+  if [[ "$validCommand" == false ]]; then
+    err "command '$subCommand' is not valid when not connected to a cluster"
+  fi
+  echo "${commands[@]}"
+}
+
+function _hr_git() {
+  local clusterConnected="${1?}"
+  local subCommand="${2?}"
+  local commands=()
+  local clonePath="$(mktemp -d)"
+  trap "rm -rf '$clonePath'" EXIT
+  local gitUrl="$3"
+  local gitRef="$4"
+  local gitPath="$5"
+  local namespace="$6"
+  local releaseName="$7"
+  local values="$8"
+
+  commands=($(_parse_hr_subcommand "$clusterConnected" "$subCommand"))
+
+  (
+    git clone -q "$gitUrl" "$clonePath"
+    cd "$clonePath"
+    git checkout -q "$gitRef"
+  ) > /dev/null
+
+  helm dependency update "$clonePath/$gitPath" > /dev/null
+  helm "${commands[@]}" ${namespace:+--namespace=$namespace} $releaseName "$clonePath/$gitPath" --values <(<<< "$values") ${@:9}
+}
+
+function printIndices() {
+  yq -ers 'map(select(.kind == "HelmRelease")) | . as $hrs | keys[] | "\(.): \($hrs[.] | "\(.metadata.namespace)/\(.metadata.name)")"' >&2
+}
+
+function helmrelease() {
+  local subCommand="${1?You need to set the command}"
+  shift
+  local commands=()
+  local clusterConnected=false
+  local namespace
+  local releaseName
+  local helmReleaseYaml
+  local numberOfHelmReleases
+  local values
+  local index
+  local sourceParameter
+  local yaml
+  local remoteKubeconfig
+  local REMOTE_KUBECONFIG
+  if kubectl version &> /dev/null; then
+    clusterConnected=true
+  fi
+  commands=($(_parse_hr_subcommand "$clusterConnected" "$subCommand"))
+
+  while [[ "$#" != 0 ]]; do
+    case "$1" in
+      -)
+        yaml=$(cat)
+        shift
+        ;;
+      -[0-9]*)
+        index="${1/-/}"
+        shift
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        if [[ -f "$1" ]]; then
+          if [[ -n "$yaml" ]]; then
+            sourceParameter="$1"
+          else
+            yaml=$(cat "$1")
+          fi
+        elif [[ -d "$1" ]]; then
+          sourceParameter="$1"
+        elif [[ "$1" =~ ^https://* ]] || [[ "$1" =~ ^oci://* ]]; then
+          sourceParameter="$1"
+        else
+          err "parameter '$1' is not supported"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  if [[ -z "$yaml" ]]; then
+    yaml=$(cat)
+  fi
+
+  numberOfHelmReleases=$(<<< "$yaml" | yq -ers 'map(select(.kind == "HelmRelease")) | length')
+  if [[ "$numberOfHelmReleases" -lt 1 ]]; then
+    err 'There are no HelmReleases in the input'
+  elif [[ "$numberOfHelmReleases" -gt 1 ]] && [[ -z "$index" ]]; then
+    if [[ "$subCommand" == "install" ]]; then
+      info 'You can only install 1 HelmReleases at the same time, but you can do `-$index`;'
+      <<<"$yaml" printIndices
+      return 1
+    else
+      <<<"$yaml" | yq -erys '.[] | select(.kind != "HelmRelease") | select(.)' \
+        | if [[ "$subCommand" = "template" ]]; then
+        cat -
+      elif [[ "$subCommand" = "diff" ]]; then
+        kubectl diff -f - || true
+      fi
+      for index in {0..$((numberOfHelmReleases - 1))}; do
+        if [[ "$subCommand" = "template" ]]; then
+          echo ---
+        fi
+        <<<"$yaml" | yq -erys '(map(select(.kind == "HelmRelease"))['"$index"']),(.[] | select(.kind | IN(["GitRepository", "HelmRepository"][])))' | helmrelease "$subCommand" - -- "${@}"
+      done
+    fi
+  else
+    index="${index:-0}"
+  fi
+  if [[ "$index" -ge "$numberOfHelmReleases" ]]; then
+    info "index '$index' is out of range"
+    <<<"$yaml" printIndices
+    exit 1
+  fi
+
+  helmReleaseYaml=$(_hr_getYaml "$yaml" "$index" HelmRelease)
+  namespace=$(_hr_getNamespace "$helmReleaseYaml")
+  remoteKubeconfig="$(<<< "$helmReleaseYaml" | yq -r '.spec.kubeConfig.secretRef.name // empty')"
+  if ! [[ -z "$remoteKubeconfig" ]] && ( [[ "$subCommand" != template ]] || [[ "$clusterConnected" == true ]] ); then
+    REMOTE_KUBECONFIG="$(mktemp)"
+    trap "rm -f \"$REMOTE_KUBECONFIG\"" EXIT
+    kubectl --namespace=$(<<<"$helmReleaseYaml" | yq -r '.metadata.namespace') get secret $remoteKubeconfig -o jsonpath='{.data.value}' | base64 -d > "$REMOTE_KUBECONFIG"
+  fi
+  releaseName=$(_hr_getReleaseName "$helmReleaseYaml")
+  case "$subCommand" in
+    uninstall)
+      KUBECONFIG="${REMOTE_KUBECONFIG:-$KUBECONFIG}" helm "${commands[@]}" ${namespace:+--namespace=$namespace} $releaseName "$@"
+      ;;
+    *)
+      values=$(<<< "$helmReleaseYaml" | yq -y -r .spec.values)
+      if [[ -e "$sourceParameter" ]]; then
+        KUBECONFIG="${REMOTE_KUBECONFIG:-$KUBECONFIG}" helm "${commands[@]}" ${namespace:+--namespace=$namespace} $releaseName "$sourceParameter" --values <(<<< "$values") ${@}
+      elif <<< "$helmReleaseYaml" | yq -e '.apiVersion == "helm.fluxcd.io/v1"' > /dev/null; then
+        if <<< "$helmReleaseYaml" | yq -e .spec.chart.git > /dev/null; then
+          local gitPath
+          local gitUrl
+          local gitRef
+          gitPath="$(<<< "$helmReleaseYaml" | yq -er '.spec.chart.path // "."')"
+          gitUrl="$(<<< "$helmReleaseYaml" | yq -er .spec.chart.git)"
+          gitRef="$(<<< "$helmReleaseYaml" | yq -er '.spec.chart.ref // "master"')"
+          KUBECONFIG="${REMOTE_KUBECONFIG:-$KUBECONFIG}" _hr_git "$clusterConnected" "$subCommand" "$gitUrl" "$gitRef" "$gitPath" "$namespace" "$releaseName" "$values" "$@"
+        else
+          KUBECONFIG="${REMOTE_KUBECONFIG:-$KUBECONFIG}" helm "${commands[@]}" ${namespace:+--namespace=$namespace} --repo $(<<< "$helmReleaseYaml" | yq -er .spec.chart.repository) $releaseName $(<<< "$helmReleaseYaml" | yq -er .spec.chart.name) --version $(<<< "$helmReleaseYaml" | yq -er .spec.chart.version) --values <(<<< "$values") "$@"
+        fi
+      else
+        local sourceNamespace
+        local sourceName
+        local sourceKind
+        local sourceResource
+        local chartName
+        local helmRepositoryUrl
+        sourceNamespace=$(<<< "$helmReleaseYaml" | yq -er ".spec.chart.spec.sourceRef.namespace // \"$namespace\"")
+        sourceName=$(<<< "$helmReleaseYaml" | yq -er .spec.chart.spec.sourceRef.name)
+        sourceKind=$(<<< "$helmReleaseYaml" | yq -er .spec.chart.spec.sourceRef.kind)
+        if [[ -z "$sourceParameter" ]]; then
+          local sourcesYaml
+          if sourcesYaml=$(_hr_getYaml "$yaml" "" "$sourceKind") || ! sourceResource=$(<<< "$sourcesYaml" | yq -erys "map(select( (.metadata.namespace == \"$sourceNamespace\") and (.metadata.name == \"$sourceName\") ))[0] // empty"); then
+            if [[ "$clusterConnected" == true ]]; then
+              if ! sourceResource=$(kubectl ${sourceNamespace:+--namespace=$sourceNamespace} get $sourceKind $sourceName -o yaml); then
+                info "Source resource '$sourceNamespace/$sourceKind/$sourceName' not found in cluster nor in input"
+              fi
+            else
+              info "Cannot get source resource '$sourceNamespace/$sourceKind/$sourceName' from cluster when not connected"
+            fi
+            if [[ -z "$sourceResource" ]]; then
+              helmRepositoryUrl="oci://ghcr.io/teutonet/teutonet-helm-charts"
+              vared -p "Please specify Helm Repository URL: " helmRepositoryUrl > /dev/null
+              sourceKind=HelmRepository
+              sourceResource=$'spec:\n  url: '"$helmRepositoryUrl"
+            fi
+          fi
+        else
+          sourceResource=$'spec:\n  url: '"$sourceParameter"
+        fi
+        chartName="$(<<< "$helmReleaseYaml" | yq -er .spec.chart.spec.chart)"
+        case "$sourceKind" in
+          GitRepository)
+            local gitUrl
+            local gitRef
+            gitUrl="$(<<< "$sourceResource" | yq -er .spec.url)"
+            gitRef="$(<<< "$sourceResource" | yq -er '.spec.ref | if .branch then .branch elif .tag then .tag elif .semver then .semver elif .commit then .commit else "master" end')"
+            KUBECONFIG="${REMOTE_KUBECONFIG:-$KUBECONFIG}" _hr_git "$clusterConnected" "$subCommand" "$gitUrl" "$gitRef" "$chartName" "$namespace" "$releaseName" "$values" "$@"
+            ;;
+          HelmRepository)
+            local chartVersion
+            helmRepositoryUrl="$(<<< "$sourceResource" | yq -er .spec.url)"
+            chartVersion="$(<<< "$helmReleaseYaml" | yq -er '.spec.chart.spec.version // "x.x.x"')"
+            commands+=( $releaseName )
+            case "$helmRepositoryUrl" in
+              https://*)
+                commands+=( --repo "$helmRepositoryUrl" "$chartName" )
+                ;;
+              oci://*)
+                commands+=( "$helmRepositoryUrl/$chartName" )
+                ;;
+              *)
+                err "'$helmRepositoryUrl' is not supported"
+                ;;
+            esac
+            KUBECONFIG="${REMOTE_KUBECONFIG:-$KUBECONFIG}" helm "${commands[@]}" ${namespace:+--namespace=$namespace} --version "$chartVersion" --values <(<<< "$values") "$@"
+            ;;
+          *)
+            err "'$sourceKind' is not implemented"
+            ;;
+        esac
+      fi
+      ;;
+  esac
+}
+
+if [[ "$XTRACE" == true ]]; then
+  set -x
+fi
+
+exec helmrelease "${@}"

--- a/helmrelease-tools/hr
+++ b/helmrelease-tools/hr
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+if [[ -o xtrace ]]; then
+  export XTRACE=true
+fi
+exec helmrelease "template" "$@"

--- a/helmrelease-tools/hrDiff
+++ b/helmrelease-tools/hrDiff
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+if [[ -o xtrace ]]; then
+  export XTRACE=true
+fi
+
+# this flag doesn't work with the dry-run switch
+if [[ "$*" == *"--allow-unreleased"* || "$*" == *"--install"* ]]; then
+  HELM_DIFF_USE_UPGRADE_DRY_RUN=false
+  HELM_DIFF_USE_INSECURE_SERVER_SIDE_DRY_RUN=false
+fi
+HELM_DIFF_USE_UPGRADE_DRY_RUN="${HELM_DIFF_USE_UPGRADE_DRY_RUN:-true}" HELM_DIFF_USE_INSECURE_SERVER_SIDE_DRY_RUN="${HELM_DIFF_USE_INSECURE_SERVER_SIDE_DRY_RUN:-true}" exec helmrelease "diff" "$@"

--- a/helmrelease-tools/hrInstall
+++ b/helmrelease-tools/hrInstall
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+if [[ -o xtrace ]]; then
+  export XTRACE=true
+fi
+exec helmrelease "install" "$@"

--- a/helmrelease-tools/hrUninstall
+++ b/helmrelease-tools/hrUninstall
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+if [[ -o xtrace ]]; then
+  export XTRACE=true
+fi
+exec helmrelease "uninstall" "$@"

--- a/helmrelease-tools/hrUpgrade
+++ b/helmrelease-tools/hrUpgrade
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+if [[ -o xtrace ]]; then
+  export XTRACE=true
+fi
+exec helmrelease "upgrade" "$@"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a comprehensive suite of command-line tools to manage Flux HelmRelease resources via Helm.
  - Added streamlined wrapper scripts for templating, diffing, installing, upgrading, and uninstalling HelmReleases.
  - Enhanced user experience with advanced Zsh command-line completions for all related commands.
  - Supported multiple HelmRelease source types, including Git and Helm repositories, with automatic environment and cluster context handling.
  - Delivered a packaged installation with dependency management and conflict resolution for easy setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->