### PR TITLE
feat: add rofi-dmenu package

### DIFF
--- a/rofi-dmenu/PKGBUILD
+++ b/rofi-dmenu/PKGBUILD
@@ -1,0 +1,15 @@
+# Maintainer Chris Werner Rau <aur@cwrau.io>
+
+pkgname=rofi-dmenu
+pkgver=2.0.0
+pkgrel=2
+pkgdesc="Symlink for using Rofi as a drop-in replacement to dmenu"
+arch=('any')
+provides=(dmenu)
+conflicts=(dmenu)
+depends=(rofi)
+
+package () {
+  install -d "$pkgdir/usr/bin"
+  ln -s /usr/bin/rofi "$pkgdir/usr/bin/dmenu"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new package that allows using rofi as a drop-in replacement for dmenu via a symlink.
  - Ensures compatibility by providing and conflicting with the original dmenu package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->